### PR TITLE
Process studies for the May 8th release

### DIFF
--- a/ai_identification/bulk_runner/README.md
+++ b/ai_identification/bulk_runner/README.md
@@ -1,0 +1,72 @@
+# bulk_runner
+
+Bulk-runs `ai_identification/stig_id_ai.py` against `vars.tsv` files pulled from
+the 73 bucket (`s3://avillach-73-bdcatalyst-etl/`) for one or more studies.
+
+For each study it:
+
+1. Downloads `s3://avillach-73-bdcatalyst-etl/dictionary/{Study Identifier}/vars.tsv`
+   to `./{Study Identifier}/vars.tsv`.
+2. Runs `stig_id_ai.py --no-header --num-columns 6` against that file, producing
+   `./{Study Identifier}/vars_FLAGGED.tsv`.
+3. Appends every flagged `concept_path` to
+   `../stigmatizing_terms/conceptsToRemove.txt` (handled by `stig_id_ai.py`).
+
+## Prerequisites
+
+Export AWS credentials in the shell before running:
+
+```sh
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+export AWS_SESSION_TOKEN=...
+```
+
+Python deps: `boto3`, `pandas` (used by `stig_id_ai.py`).
+
+## Usage
+
+The script takes either a CSV of studies or a single study identifier (mutually
+exclusive, one is required).
+
+### CSV mode
+
+```sh
+python3 run_stigvars_on_managed_inputs.py --input-csv "BDC Managed Inputs.csv"
+```
+
+Only rows where `Data is ready to process` is `Yes` **and** `Data Processed` is
+`No` are processed.
+
+#### Expected CSV columns
+
+The CSV's first row must be a header. The following columns are required (other
+columns are ignored, so `BDC Managed Inputs.csv` works as-is):
+
+| Column                      | Used for                                                  |
+| --------------------------- | --------------------------------------------------------- |
+| `Study Identifier`          | `datasetId` — used as the S3 path segment and local dir.  |
+| `Data is ready to process`  | Filter: row is processed only when this equals `Yes`.     |
+| `Data Processed`            | Filter: row is processed only when this equals `No`.      |
+
+Matching on the filter columns is case-insensitive and trims surrounding whitespace.
+
+### Single-study mode
+
+```sh
+python3 run_stigvars_on_managed_inputs.py --study-identifier phs004526
+```
+
+No filtering is applied; the given study is always processed.
+
+## Outputs
+
+- `./{Study Identifier}/vars.tsv` — raw file pulled from S3.
+- `./{Study Identifier}/vars_FLAGGED.tsv` — three-column TSV
+  (`concept_path`, `is_stigmatizing`, `Category`) produced by `stig_id_ai.py`.
+- `../stigmatizing_terms/conceptsToRemove.txt` — appended with the flagged
+  `concept_path`s from each study.
+
+Studies whose `vars.tsv` is missing in S3 are skipped and reported in stderr;
+the run continues with the remaining studies. A summary
+(`done: processed=…, skipped=…`) is printed at the end.

--- a/ai_identification/bulk_runner/run_stigvars_on_managed_inputs.py
+++ b/ai_identification/bulk_runner/run_stigvars_on_managed_inputs.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# Step 1: The user will have exported their AWS access variables on the terminal runnning this script.
+## Exported variables on terminal are AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN
+# Step 2: Read input csv (passed as an argument)
+# First row is header. Read columns by name
+# Step 3: Download var.tsv for each study from 73 bucket
+# 73 bucket is = s3://avillach-73-bdcatalyst-etl/
+# Path to var.tsv = s3://avillach-73-bdcatalyst-etl/dictionary/${datasetId}/vars.tsv
+## datasetId = Study Identifier in "BDC Managed Inputs.csv"
+## Place each file in a directory "./{Study Identifier}/vars.tsv" to be processed later
+# Step 7: run the stig_id_ai.py against the vars.tsv for each study to update the concepts to remove
+## Open Question: Does the concept to remove need to be uploaded or is it automatically pulled by the ETL?
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import boto3
+from botocore.exceptions import ClientError
+
+BUCKET = "avillach-73-bdcatalyst-etl"
+VARS_KEY_TEMPLATE = "dictionary/{dataset_id}/vars.tsv"
+
+THIS_DIR = Path(__file__).resolve().parent
+AI_ID_DIR = THIS_DIR.parent
+STIG_ID_AI = AI_ID_DIR / "stig_id_ai.py"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run stig_id_ai.py against vars.tsv files pulled from the 73 bucket. "
+                    "Provide either --input-csv (one row per study) or --study-identifier (single study)."
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--input-csv",
+        help='Path to a CSV with a "Study Identifier" column (e.g. "BDC Managed Inputs.csv").',
+    )
+    group.add_argument(
+        "--study-identifier",
+        help="Single study identifier (datasetId), e.g. phs004526.",
+    )
+    return parser.parse_args()
+
+
+def iter_dataset_ids(args: argparse.Namespace):
+    if args.study_identifier:
+        yield args.study_identifier.strip()
+        return
+
+    required = ("Study Identifier", "Data is ready to process", "Data Processed")
+    with open(args.input_csv, "r", encoding="utf-8", newline="") as fin:
+        reader = csv.DictReader(fin)
+        missing = [c for c in required if c not in (reader.fieldnames or [])]
+        if missing:
+            raise SystemExit(f"Input CSV is missing required column(s): {', '.join(missing)}")
+        for row in reader:
+            dataset_id = (row.get("Study Identifier") or "").strip()
+            ready = (row.get("Data is ready to process") or "").strip().lower()
+            processed = (row.get("Data Processed") or "").strip().lower()
+            if not dataset_id or ready != "yes" or processed != "no":
+                continue
+            yield dataset_id
+
+
+def download_vars_tsv(s3_client, dataset_id: str, dest_dir: Path) -> Path | None:
+    key = VARS_KEY_TEMPLATE.format(dataset_id=dataset_id)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest_path = dest_dir / "vars.tsv"
+    try:
+        s3_client.download_file(BUCKET, key, str(dest_path))
+    except ClientError as exc:
+        print(f"  skip {dataset_id}: s3://{BUCKET}/{key} -> {exc.response['Error'].get('Code', 'Error')}", file=sys.stderr)
+        return None
+    return dest_path
+
+
+def run_stig_id_ai(vars_path: Path, dataset_id: str) -> bool:
+    output_path = vars_path.with_name("vars_FLAGGED.tsv")
+    cmd = [
+        sys.executable,
+        str(STIG_ID_AI),
+        "--input", str(vars_path),
+        "--output", str(output_path),
+        "--no-header",
+        "--num-columns", "6",
+    ]
+    # stig_id_ai.py appends to ../stigmatizing_terms/conceptsToRemove.txt, so run it from ai_identification/.
+    result = subprocess.run(cmd, cwd=AI_ID_DIR)
+    if result.returncode != 0:
+        print(f"  stig_id_ai.py failed for {dataset_id} (exit {result.returncode})", file=sys.stderr)
+        return False
+    return True
+
+
+def main() -> int:
+    args = parse_args()
+
+    s3_client = boto3.client("s3")
+
+    processed = 0
+    skipped = 0
+    for dataset_id in iter_dataset_ids(args):
+        print(f"[{dataset_id}] downloading vars.tsv")
+        study_dir = THIS_DIR / dataset_id
+        vars_path = download_vars_tsv(s3_client, dataset_id, study_dir)
+        if vars_path is None:
+            skipped += 1
+            continue
+
+        print(f"[{dataset_id}] running stig_id_ai.py")
+        if run_stig_id_ai(vars_path, dataset_id):
+            processed += 1
+        else:
+            skipped += 1
+
+    print(f"done: processed={processed}, skipped={skipped}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ai_identification/bulk_runner/run_stigvars_on_managed_inputs.py
+++ b/ai_identification/bulk_runner/run_stigvars_on_managed_inputs.py
@@ -1,16 +1,4 @@
 #!/usr/bin/env python3
-# Step 1: The user will have exported their AWS access variables on the terminal runnning this script.
-## Exported variables on terminal are AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN
-# Step 2: Read input csv (passed as an argument)
-# First row is header. Read columns by name
-# Step 3: Download var.tsv for each study from 73 bucket
-# 73 bucket is = s3://avillach-73-bdcatalyst-etl/
-# Path to var.tsv = s3://avillach-73-bdcatalyst-etl/dictionary/${datasetId}/vars.tsv
-## datasetId = Study Identifier in "BDC Managed Inputs.csv"
-## Place each file in a directory "./{Study Identifier}/vars.tsv" to be processed later
-# Step 7: run the stig_id_ai.py against the vars.tsv for each study to update the concepts to remove
-## Open Question: Does the concept to remove need to be uploaded or is it automatically pulled by the ETL?
-
 from __future__ import annotations
 
 import argparse


### PR DESCRIPTION
- Update conceptsToRemove for the May 8th data release.
- Add a bulk runner that allows a person to bulk process `vars.tsv` files. This allows you to pass a single study or a csv file. See the readme.